### PR TITLE
Set meta[http-equiv] and meta[name='viewport']

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,6 +1,8 @@
 doctype html
 html
   head
+    meta[http-equiv='X-UA-Compatible' content='IE=edge']
+    meta[name='viewport' content='width=device-width, initial-scale=1']
     title
       | Todos
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true


### PR DESCRIPTION
We forgot to set the viewport width (and other meta tags), so the app
wasn't displaying responsively on mobile.
- Set viewport width and initial scale
- Set http-equiv to X-UA-Compatible
