### PR TITLE
Hotfix: Add Heorku ActionMailer configs to prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,30 @@ rake db:create
 rake db:migrate
 ```
 
+### Setting up Environment variables
+
 Setup a `.env` file if you want to be able to send mails in Devise on your
 development system. The `dotenv-rails` gem will automatically load these
 environment variables when you start your server.
 
 ```sh
 # /.env
+RAILS_MAILER_HOST = 'yourapp.herokuapp.com'
 RAILS_SMTP_ADDRESS = 'smtp.gmail.com'
 RAILS_SMTP_PORT = 587
 RAILS SMTP_DOMAIN = 'gmail.com'
 RAILS_SMTP_USERNAME = 'user@gmail.com'
 RAILS_SMTP_PASSWORD = 'password1234'
+DEVISE_MAILER_SENDER = 'user@gmail.com'
 ```
+
+For some services (such as Postmark), the `USERNAME` and `SIGNATURE` will be
+different---eg the former will be an API token while the latter will be a
+verified email that appears as the sender to recipients. Resonable defaults are
+provided in the dev environment, but at the very least `USERNAME` and `PASSWORD`
+need to be changed if you are using GMail as an SMTP sender.
+
+### Starting the server
 
 Start the server locally:
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,13 +20,13 @@ Rails.application.configure do
     port: ENV['RAILS_MAILER_PORT'],
   }
   config.action_mailer.smtp_settings = {
-    address: ENV['RAILS_SMTP_ADDRESS'],
-    port: ENV['RAILS_SMTP_PORT'].to_i,
-    domain: ENV['RAILS_SMTP_DOMAIN'],
-    authentication: 'plain',
+    address: ENV['RAILS_SMTP_ADDRESS'] || 'gmail.smtp.com',
+    port: ENV['RAILS_SMTP_PORT'].to_i || 587,
+    domain: ENV['RAILS_SMTP_DOMAIN'] || 'gmail.com',
+    authentication: ENV['RAILS_SMTP_AUTH'] || 'plain',
     enable_starttls_auto: true,
-    user_name: ENV['RAILS_SMTP_USERNAME'],
-    password: ENV['RAILS_SMTP_PASSWORD'],
+    user_name: ENV['RAILS_SMTP_USERNAME'] || 'user@gmail.com',
+    password: ENV['RAILS_SMTP_PASSWORD'] || 'password',
   }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,9 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default charset: 'utf-8'
   config.action_controller.perform_caching = true
   config.action_mailer.raise_delivery_errors = false
 
@@ -74,7 +77,7 @@ Rails.application.configure do
     address: ENV['RAILS_SMTP_ADDRESS'],
     port: ENV['RAILS_SMTP_PORT'].to_i,
     domain: ENV['RAILS_SMTP_DOMAIN'],
-    authentication: 'plain',
+    authentication: :cram_md5,
     enable_starttls_auto: true,
     user_name: ENV['RAILS_SMTP_USERNAME'],
     password: ENV['RAILS_SMTP_PASSWORD'],

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['DEVISE_MAILER_SENDER'] || 'set-your-sender-address-in-your-environment@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Heroku wasn't sending mail, so it needs a few extra config options.

``` ruby
config.action_mailer.delivery_method = :smtp
config.action_mailer.perform_deliveries = true
config.action_mailer.default charset: 'utf-8'
```
