### PR TITLE
Users can own their lists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,5 @@ Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'
+Style/GuardClause:
+  Enabled: false

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,19 @@
 .jumbotron {
   background-color: $brand-primary;
   color: $body-bg;
+  a {
+    color: #fff;
+  }
+  &.no-navbar-margin {
+    margin-top: -21px;
+  }
+  .jumbotron-actions {
+    margin: 0 auto;
+    width: -moz-fit-content;
+    width: -webkit-fit-content;
+    width: fit-content;
+    text-align: center;
+  }
 }
 
 .field_with_errors {

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -28,3 +28,9 @@
     }
   }
 }
+
+.jumbotron {
+  .btn-outline {
+      color: #fff;
+  }
+}

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -2,10 +2,6 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.navbar {
-  margin-bottom: 0;
-}
-
 main {
   section {
     margin-left: 1em;

--- a/app/controllers/todo_lists_controller.rb
+++ b/app/controllers/todo_lists_controller.rb
@@ -1,10 +1,16 @@
 class TodoListsController < ApplicationController
   before_action :set_todo_list, only: [:destroy]
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :index
   before_action :authorize_ownership!, only: [:edit, :update, :show, :destroy]
 
   def index
-    @todo_lists = current_user.todo_lists
+    if current_user
+      @todo_lists = current_user.todo_lists
+      render :index
+    else
+      @todo_lists = []
+      render :welcome
+    end
   end
 
   def show

--- a/app/controllers/todo_lists_controller.rb
+++ b/app/controllers/todo_lists_controller.rb
@@ -1,7 +1,10 @@
 class TodoListsController < ApplicationController
-  before_action :set_todo_list, only: [:show, :edit, :update, :destroy]
+  before_action :set_todo_list, only: [:destroy]
+  before_action :authenticate_user!
+  before_action :authorize_ownership!, only: [:edit, :update, :show, :destroy]
+
   def index
-    @todo_lists = TodoList.all
+    @todo_lists = current_user.todo_lists
   end
 
   def show
@@ -23,11 +26,11 @@ class TodoListsController < ApplicationController
   end
 
   def new
-    @todo_list = TodoList.new
+    @todo_list = current_user.todo_lists.new
   end
 
   def create
-    @todo_list = TodoList.new(todo_list_params)
+    @todo_list = current_user.todo_lists.new(todo_list_params)
     if @todo_list.save
       flash[:notice] = 'Todo List successfully created.'
       redirect_to @todo_list
@@ -43,6 +46,14 @@ class TodoListsController < ApplicationController
   end
 
   private
+
+  def authorize_ownership!
+    @todo_list = current_user.todo_lists.find_by_id(params[:id])
+    if @todo_list.nil? || current_user != @todo_list.user
+      flash[:alert] = 'You are not the owner of that list or the list does not exist.'
+      redirect_to root_path
+    end
+  end
 
   def set_todo_list
     @todo_list = TodoList.find(params[:id])

--- a/app/models/todo_list.rb
+++ b/app/models/todo_list.rb
@@ -1,5 +1,6 @@
 class TodoList < ActiveRecord::Base
   has_many :todo_items, dependent: :destroy
+  belongs_to :user
 
   validates :name, presence: true
   validates :name, length: { minimum: 3, maximum: 32 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :todo_lists
 end

--- a/app/views/static_pages/about.html.slim
+++ b/app/views/static_pages/about.html.slim
@@ -1,4 +1,4 @@
-.jumbotron
+.jumbotron.no-navbar-margin
   .container
     h1 About
     p Todos is a simple Todo app in Rails

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -1,4 +1,4 @@
-.jumbotron
+.jumbotron.no-navbar-margin
   .container
     h1 Contact
     p Contact the operator of Todos if you have any suggesstions, feedback,
@@ -13,10 +13,14 @@
     a<> href="https://github.com/eToThePiIPower/todos" project page on Github.
     | If you have an improvement submit a pull request.
 
+  hr
+
   h2
     i.fa.fa-support
     |  Support
   p Support is handled via Github issues.
+
+  hr
 
   h2
     i.fa.fa-code

--- a/app/views/todo_lists/welcome.html.slim
+++ b/app/views/todo_lists/welcome.html.slim
@@ -1,0 +1,14 @@
+.jumbotron.no-navbar-margin
+  .container
+    h1 Welcome
+    p Todos is an app for prioritizing your tasks.
+
+    .jumbotron-actions
+      p
+        = link_to 'Sign Up Now', '#signup',
+            data: { toggle: 'modal', keyboard: true },
+            class: 'btn btn-default btn-lg btn-outline'
+      p
+        = link_to 'Already a user? Log in', '#login',
+            data: { toggle: 'modal', keyboard: true },
+            class: 'btn btn-default btn-sm btn-outline'

--- a/db/migrate/20160629000036_add_user_to_todo_lists.rb
+++ b/db/migrate/20160629000036_add_user_to_todo_lists.rb
@@ -1,0 +1,5 @@
+class AddUserToTodoLists < ActiveRecord::Migration
+  def change
+    add_reference :todo_lists, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160627143015) do
+ActiveRecord::Schema.define(version: 20160629000036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,10 @@ ActiveRecord::Schema.define(version: 20160627143015) do
     t.string   "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "user_id"
   end
+
+  add_index "todo_lists", ["user_id"], name: "index_todo_lists_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -51,4 +54,5 @@ ActiveRecord::Schema.define(version: 20160627143015) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "todo_items", "todo_lists"
+  add_foreign_key "todo_lists", "users"
 end

--- a/spec/controllers/todo_lists_controller_spec.rb
+++ b/spec/controllers/todo_lists_controller_spec.rb
@@ -195,11 +195,11 @@ RSpec.describe TodoListsController, type: :controller do
     end
 
     context 'when nobody is logged in' do
-      it 'redirects to the login page with an error' do
+      it 'renders the welcome page and assigns todo_lists as empty' do
         get :index
 
-        expect(assigns(:todo_lists)).to be_nil
-        expect_it_to_require_the_user_be_signed_in
+        expect(assigns(:todo_lists)).to be_empty
+        expect(response).to render_template :welcome
       end
     end
   end

--- a/spec/controllers/todo_lists_controller_spec.rb
+++ b/spec/controllers/todo_lists_controller_spec.rb
@@ -2,88 +2,276 @@ require 'rails_helper'
 
 RSpec.describe TodoListsController, type: :controller do
   describe 'POST #create' do
-    context 'with valid params' do
-      it 'redirects to the newly created todo list' do
-        post :create, todo_list: attributes_for(:todo_list)
+    context 'when a user is logged in' do
+      before do
+        @user = create(:user)
+        sign_in @user
+      end
 
-        expect(response).to redirect_to TodoList.last
-        expect(flash[:notice]).to match(/^Todo List successfully created./)
+      context 'with valid params' do
+        it 'redirects to the newly created todo list' do
+          @todo_list = attributes_for(:todo_list)
+
+          post :create, todo_list: @todo_list
+
+          expect(response).to redirect_to TodoList.last
+          expect(flash[:notice]).to match(/^Todo List successfully created./)
+          expect(TodoList.last).to belong_to_user @user
+        end
+      end
+
+      context 'with invalid params' do
+        it 'renders the form with errors when' do
+          @todo_list = attributes_for(:invalid_todo_list)
+
+          post :create, todo_list: @todo_list
+
+          expect(response).to render_template :new
+          expect(flash[:error]).to match(/^Validation errors./)
+        end
       end
     end
 
-    context 'with invalid params' do
-      it 'renders the form with errors' do
-        post :create, todo_list: attributes_for(:invalid_todo_list)
+    context 'when no user is logged in' do
+      it 'redirects to the log in form' do
+        post :create, todo_list: attributes_for(:todo_list)
 
-        expect(response).to render_template :new
-        expect(flash[:error]).to match(/^Validation errors./)
+        expect(response).to redirect_to new_user_session_path
+        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
       end
     end
   end
 
   describe 'POST #update' do
-    context 'with valid params' do
-      it 'redirects to the newly updated todo list' do
-        @todo_list = create(:todo_list)
+    context 'when the owner is logged in' do
+      before do
+        @user = create(:user)
+        @todo_list = @user.todo_lists.create(attributes_for(:todo_list))
+        sign_in @user
+      end
 
-        put :update, id: @todo_list, todo_list: { name: 'New Name' }
+      context 'with valid params' do
+        it 'redirects to the newly updated todo list' do
+          put :update, id: @todo_list, todo_list: { name: 'New Name' }
+          @todo_list.reload
 
-        expect(response).to redirect_to @todo_list
-        expect(flash[:notice]).to match(/^Todo List successfully updated./)
+          expect(@todo_list.name).to eq 'New Name'
+          expect(response).to redirect_to @todo_list
+          expect(flash[:notice]).to match(/^Todo List successfully updated./)
+        end
+      end
+
+      context 'with invalid params' do
+        it 'renders the form with errors' do
+          put :update, id: @todo_list, todo_list: { name: '' }
+          @todo_list.reload
+
+          expect(@todo_list.name).not_to eq ''
+          expect(response).to render_template :edit
+          expect(flash[:error]).to match(/^Validation errors./)
+        end
       end
     end
 
-    context 'with invalid params' do
-      it 'renders the form with errors' do
-        @todo_list = create(:todo_list)
+    context 'when another user is logged in' do
+      before do
+        @owner = create(:user)
+        @todo_list = @owner.todo_lists.create(attributes_for(:todo_list))
+        @user = create(:user)
+        sign_in @user
+      end
 
-        put :update, id: @todo_list, todo_list: { name: '' }
+      context 'with valid params' do
+        it 'redirects to the root page with an error' do
+          put :update, id: @todo_list, todo_list: { name: 'New Name' }
+          @todo_list.reload
 
-        expect(response).to render_template :edit
-        expect(flash[:error]).to match(/^Validation errors./)
+          expect(@todo_list.name).not_to eq 'New Name'
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+        end
+      end
+
+      context 'when the list does not exist' do
+        it 'redirects to the root page with an error' do
+          put :update, id: (@todo_list.id + 1), todo_list: { name: 'New Name' }
+          @todo_list.reload
+
+          expect(@todo_list.name).not_to eq 'New Name'
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+        end
+      end
+    end
+
+    context 'when nobody is logged in' do
+      before do
+        @owner = create(:user)
+        @todo_list = @owner.todo_lists.create(attributes_for(:todo_list))
+      end
+
+      context 'with valid params' do
+        it 'redirects to the login page with an error' do
+          put :update, id: @todo_list, todo_list: { name: 'New Name' }
+          @todo_list.reload
+
+          expect(@todo_list.name).not_to eq 'New Name'
+          expect(response).to redirect_to new_user_session_path
+          expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+        end
       end
     end
   end
 
   describe 'GET #show' do
-    it 'assigns the list and an array of its items' do
-      @todo_list = create(:todo_list_with_items)
-      @todo_items = @todo_list.todo_items
+    context 'when the owner is logged in' do
+      before do
+        @user = create(:user)
+        @todo_list = @user.todo_lists.create(attributes_for(:todo_list))
+        sign_in @user
+      end
 
-      get :show, id: @todo_list
+      it 'assigns the list and an array of its items' do
+        get :show, id: @todo_list
 
-      expect(assigns(:todo_list)).to eq @todo_list
-      expect(assigns(:todo_items)).to eq @todo_items
+        expect(assigns(:todo_list)).to eq @todo_list
+        expect(assigns(:todo_items)).to eq @todo_list.todo_items
+      end
+    end
+
+    context 'when another user is logged in' do
+      before do
+        @owner = create(:user)
+        @todo_list = @owner.todo_lists.create(attributes_for(:todo_list))
+        @user = create(:user)
+        sign_in @user
+      end
+
+      it 'redirects to the root page with an error' do
+        get :show, id: @todo_list
+
+        expect(assigns(:todo_list)).to be_nil
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+      end
+    end
+
+    context 'when nobody is logged in' do
+      before do
+        @owner = create(:user)
+        @todo_list = @owner.todo_lists.create(attributes_for(:todo_list))
+      end
+
+      it 'redirects to the login page with an error' do
+        get :show, id: @todo_list
+
+        expect(assigns(:todo_list)).to be_nil
+        expect(response).to redirect_to new_user_session_path
+        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+      end
     end
   end
 
   describe 'GET #index' do
-    it 'retrieves all of the todo lists' do
-      3.times { create(:todo_list) }
+    before do
+      @user = create(:user)
+      3.times { @user.todo_lists.create(attributes_for(:todo_list)) }
+    end
+    context 'when a user is logged in' do
+      it "retrieves all of the user's todo lists" do
+        sign_in @user
+        get :index
 
-      get :index
+        expect(response).to render_template :index
+        expect(assigns(:todo_lists).length).to be(3)
+        expect(assigns(:todo_lists)).to eq(@user.todo_lists)
+      end
 
-      expect(response).to render_template :index
-      expect(assigns(:todo_lists).length).to be(3)
-      expect(assigns(:todo_lists).first).to eq(TodoList.first)
+      it "retrieves only that user's todo lists" do
+        @other_user = create(:user)
+        3.times { @other_user.todo_lists.create(attributes_for(:todo_list)) }
+
+        sign_in @user
+        get :index
+
+        expect(response).to render_template :index
+        expect(assigns(:todo_lists).length).to be(3)
+        expect(assigns(:todo_lists)).to eq(@user.todo_lists)
+      end
+    end
+
+    context 'when nobody is logged in' do
+      it 'redirects to the login page with an error' do
+        get :index
+
+        expect(assigns(:todo_lists)).to be_nil
+        expect(response).to redirect_to new_user_session_path
+        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+      end
     end
   end
 
   describe 'DELETE #destroy' do
-    it 'destroys the todo list' do
-      @todo_list = create(:todo_list)
+    context 'when the owner is logged in' do
+      before do
+        @user = create(:user)
+        @todo_list = @user.todo_lists.create(attributes_for(:todo_list))
+        sign_in @user
+      end
 
-      expect do
+      it 'destroys the todo list' do
+        expect do
+          delete :destroy, id: @todo_list
+        end.to change(TodoList, :count).by(-1)
+      end
+
+      it 'redirects to the index' do
         delete :destroy, id: @todo_list
-      end.to change(TodoList, :count).by(-1)
+
+        expect(response).to redirect_to :todo_lists
+      end
     end
 
-    it 'redirects to the index' do
-      @todo_list = create(:todo_list)
+    context 'when another user is logged in' do
+      before do
+        @owner = create(:user)
+        @todo_list = @owner.todo_lists.create(attributes_for(:todo_list))
+        @user = create(:user)
+        sign_in @user
+      end
 
-      delete :destroy, id: @todo_list
+      it 'does not destroy the todo list' do
+        expect do
+          delete :destroy, id: @todo_list
+        end.not_to change(TodoList, :count)
+      end
 
-      expect(response).to redirect_to :todo_lists
+      it 'redirects to the root page with an error' do
+        delete :destroy, id: @todo_list
+
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+      end
+    end
+
+    context 'when nobody is logged in' do
+      before do
+        @owner = create(:user)
+        @todo_list = @owner.todo_lists.create(attributes_for(:todo_list))
+      end
+
+      it 'does not destroy the todo list' do
+        expect do
+          delete :destroy, id: @todo_list
+        end.not_to change(TodoList, :count)
+      end
+
+      it 'redirects to the login page with an error' do
+        delete :destroy, id: @todo_list
+
+        expect(response).to redirect_to new_user_session_path
+        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+      end
     end
   end
 end

--- a/spec/controllers/todo_lists_controller_spec.rb
+++ b/spec/controllers/todo_lists_controller_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe TodoListsController, type: :controller do
       it 'redirects to the log in form' do
         post :create, todo_list: attributes_for(:todo_list)
 
-        expect(response).to redirect_to new_user_session_path
-        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+        expect_it_to_require_the_user_be_signed_in
       end
     end
   end
@@ -87,8 +86,7 @@ RSpec.describe TodoListsController, type: :controller do
           @todo_list.reload
 
           expect(@todo_list.name).not_to eq 'New Name'
-          expect(response).to redirect_to root_path
-          expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+          expect_it_to_return_an_authorization_error
         end
       end
 
@@ -98,8 +96,7 @@ RSpec.describe TodoListsController, type: :controller do
           @todo_list.reload
 
           expect(@todo_list.name).not_to eq 'New Name'
-          expect(response).to redirect_to root_path
-          expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+          expect_it_to_return_an_authorization_error
         end
       end
     end
@@ -116,8 +113,7 @@ RSpec.describe TodoListsController, type: :controller do
           @todo_list.reload
 
           expect(@todo_list.name).not_to eq 'New Name'
-          expect(response).to redirect_to new_user_session_path
-          expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+          expect_it_to_require_the_user_be_signed_in
         end
       end
     end
@@ -151,8 +147,7 @@ RSpec.describe TodoListsController, type: :controller do
         get :show, id: @todo_list
 
         expect(assigns(:todo_list)).to be_nil
-        expect(response).to redirect_to root_path
-        expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+        expect_it_to_return_an_authorization_error
       end
     end
 
@@ -166,8 +161,7 @@ RSpec.describe TodoListsController, type: :controller do
         get :show, id: @todo_list
 
         expect(assigns(:todo_list)).to be_nil
-        expect(response).to redirect_to new_user_session_path
-        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+        expect_it_to_require_the_user_be_signed_in
       end
     end
   end
@@ -205,8 +199,7 @@ RSpec.describe TodoListsController, type: :controller do
         get :index
 
         expect(assigns(:todo_lists)).to be_nil
-        expect(response).to redirect_to new_user_session_path
-        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+        expect_it_to_require_the_user_be_signed_in
       end
     end
   end
@@ -249,8 +242,7 @@ RSpec.describe TodoListsController, type: :controller do
       it 'redirects to the root page with an error' do
         delete :destroy, id: @todo_list
 
-        expect(response).to redirect_to root_path
-        expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+        expect_it_to_return_an_authorization_error
       end
     end
 
@@ -269,8 +261,7 @@ RSpec.describe TodoListsController, type: :controller do
       it 'redirects to the login page with an error' do
         delete :destroy, id: @todo_list
 
-        expect(response).to redirect_to new_user_session_path
-        expect(flash[:alert]).to match(/^You need to sign in or sign up./)
+        expect_it_to_require_the_user_be_signed_in
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :user do
-    email 'user@example.com'
+    sequence :email do |n|
+      "person#{n}@example.com"
+    end
     password 'password'
     password_confirmation 'password'
   end

--- a/spec/features/user_adds_a_todo_item_spec.rb
+++ b/spec/features/user_adds_a_todo_item_spec.rb
@@ -1,6 +1,8 @@
 feature 'User adds a todo item' do
   before do
-    @todo_list = create(:todo_list)
+    @user = create(:user)
+    @todo_list = @user.todo_lists.create(attributes_for(:todo_list))
+    login_as @user
   end
 
   scenario 'they see the list on the page' do

--- a/spec/features/user_can_edit_their_account_spec.rb
+++ b/spec/features/user_can_edit_their_account_spec.rb
@@ -1,12 +1,7 @@
 feature 'User can edit their account' do
   before do
     @user = create(:user)
-    visit root_path
-    within("//form[@id='modal-login-form']") do
-      fill_in 'Email', with: @user.email
-      fill_in 'Password', with: @user.password
-      click_button 'Log In'
-    end
+    login_as(@user)
   end
 
   scenario 'they change their email address' do

--- a/spec/features/user_creates_a_list_spec.rb
+++ b/spec/features/user_creates_a_list_spec.rb
@@ -1,5 +1,8 @@
 feature 'User creates a list' do
   scenario 'they see the list form on the page' do
+    @user = create(:user)
+    login_as(@user)
+
     visit new_todo_list_path
 
     fill_in 'Name', with: 'My List'

--- a/spec/features/user_destroys_a_todo_item_spec.rb
+++ b/spec/features/user_destroys_a_todo_item_spec.rb
@@ -1,7 +1,9 @@
 feature 'User destroys a todo item' do
   before do
-    @todo_list = create(:todo_list)
+    @user = create(:user)
+    @todo_list = @user.todo_lists.create(attributes_for(:todo_list))
     @todo_item = @todo_list.todo_items.create(attributes_for(:todo_item))
+    login_as @user
   end
 
   scenario 'they see the list on the page' do

--- a/spec/models/todo_list_spec.rb
+++ b/spec/models/todo_list_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe TodoList, type: :model do
   it { should have_many :todo_items }
+  it { should belong_to :user }
 
   it { should validate_presence_of :name }
   it { should validate_length_of(:name).is_at_least(3).is_at_most(32) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  it { should have_many :todo_lists }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/factory_girl'
 require 'support/login_helpers'
+require 'support/macros'
 Dir[File.dirname(__FILE__) + '/support/matchers/*.rb'].each { |f| require f }
 
 require 'simplecov'
@@ -72,6 +73,7 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   # Include custom spec helpers
   config.include LoginHelpers
+  config.include Macros
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,8 +5,11 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/factory_girl'
+require 'support/login_helpers'
+Dir[File.dirname(__FILE__) + '/support/matchers/*.rb'].each { |f| require f }
 
 require 'simplecov'
 SimpleCov.start do
@@ -65,6 +68,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::TestHelpers, type: :controller
+  # Include custom spec helpers
+  config.include LoginHelpers
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -1,0 +1,16 @@
+module LoginHelpers
+  def login_as(user)
+    visit new_user_session_path
+    within("//form[@id='modal-login-form']") do
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Log In'
+    end
+  end
+
+  def create_and_login_as_user
+    user = FactoryGirl.create(:user)
+    login_as(user)
+    user
+  end
+end

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -1,0 +1,11 @@
+module Macros
+  def expect_it_to_require_the_user_be_signed_in
+    expect(response).to redirect_to new_user_session_path
+    expect(flash[:alert]).to match(/^You need to sign in or sign up before continuing./)
+  end
+
+  def expect_it_to_return_an_authorization_error
+    expect(response).to redirect_to root_path
+    expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+  end
+end

--- a/spec/support/matchers/belong_to_user.rb
+++ b/spec/support/matchers/belong_to_user.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :belong_to_user do |expected|
+  match do |actual|
+    actual.user == expected
+  end
+end

--- a/spec/views/todo_lists/index.html.slim_spec.rb
+++ b/spec/views/todo_lists/index.html.slim_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'todo_lists/index.html.slim' do
+  context 'when there are no todo lists' do
+    context 'when a user is logged in' do
+      it 'encourages the user to create a todo list' do
+        view.stub(:current_user) { build(:user) }
+        assign(:todo_lists, [])
+
+        render
+
+        expect(rendered).to have_selector("a[href='#{new_todo_list_path}']", 'Create Todo List')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Todo Lists are now owned by their users, and only the owners can
view, update, and destroy them.

Added a welcome page for non-logged-in users. This page is pretty basic for the moment.

While there is no interface to destroy TodoItems for non-owners, there is currently
no guarantee non-owner and anonymous users can't delete items directly through a POST
request. That will be taken care of in the next feature set focussing on TodoItems.

Several utility features added, including:
- Some RSpec macros for testing authentication/authorization
- Jumbotron styling fixes, particularly for buttons and the navbar margin
