### PR TITLE
TodoItem security fix: Users could delete any item

### DIFF
--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -1,5 +1,6 @@
 class TodoItem < ActiveRecord::Base
   belongs_to :todo_list
+  delegate :user, to: :todo_list
 
   validates :todo_list, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :todo_lists
+  has_many :todo_items, through: :todo_lists
 end

--- a/spec/controllers/todo_items_controller_spec.rb
+++ b/spec/controllers/todo_items_controller_spec.rb
@@ -2,38 +2,106 @@ require 'rails_helper'
 
 RSpec.describe TodoItemsController, type: :controller do
   describe 'POST #create' do
-    context 'with valid params' do
-      it 'renders the parent todo list with success message' do
-        @todo_list = create(:todo_list)
+    before do
+      @owner = create(:user)
+      @todo_list = create(:todo_list, user: @owner)
+    end
 
-        post :create, todo_list_id: @todo_list, todo_item: attributes_for(:todo_item), todo_list: @todo_list
+    context 'when the user owns the list' do
+      before do
+        sign_in @owner
+      end
 
-        expect(flash[:notice]).to match(/^Item successfully added./)
-        expect(response).to redirect_to @todo_list
+      context 'with valid params' do
+        it 'renders the parent todo list with success message' do
+          expect do
+            post :create, todo_item: attributes_for(:todo_item),
+                          todo_list_id: @todo_list
+          end.to change(TodoItem, :count).by(1)
+
+          expect(flash[:notice]).to match(/^Item successfully added./)
+          expect(response).to redirect_to @todo_list
+        end
+      end
+
+      context 'with invalid params' do
+        it 'renders the parent todo list with errors' do
+          expect do
+            post :create, todo_item: attributes_for(:todo_item, name: ''),
+                          todo_list_id: @todo_list
+          end.not_to change(TodoItem, :count)
+
+          expect(flash[:error]).to match(/^Error adding item./)
+          expect(response).to redirect_to @todo_list
+        end
       end
     end
 
-    context 'with invalid params' do
-      it 'renders the parent todo list with errors' do
-        @todo_list = create(:todo_list)
+    context 'when the user does not own the list' do
+      it 'does nothing and returns an error' do
+        @user = create(:user)
+        sign_in @user
 
-        post :create, todo_list_id: @todo_list, todo_item: attributes_for(:todo_item, name: '')
+        expect do
+          post :create, todo_list_id: @todo_list,
+                        todo_item: attributes_for(:todo_item)
+        end.not_to change(TodoItem, :count)
 
-        expect(flash[:error]).to match(/^Error adding item./)
-        expect(response).to redirect_to @todo_list
+        expect_it_to_return_an_authorization_error
+      end
+    end
+
+    context 'when the user is not signed in' do
+      it 'does nothing and returns an error' do
+        expect do
+          post :create, todo_list_id: @todo_list,
+                        todo_item: attributes_for(:todo_item)
+        end.not_to change(TodoItem, :count)
+
+        expect_it_to_require_the_user_be_signed_in
       end
     end
   end
 
   describe 'DELETE #destroy' do
-    context 'with a valid item' do
-      it 'destroys the item and flashes success' do
-        @todo_list = create(:todo_list_with_items, items_count: 5)
-        @todo_item = @todo_list.todo_items.first
+    before do
+      @owner = create(:user)
+      @todo_list = create(:todo_list_with_items, items_count: 5, user: @owner)
+      @todo_item = @todo_list.todo_items.first
+    end
 
-        delete :destroy, id: @todo_item, todo_list_id: @todo_list
+    context 'when the user owns the containing list' do
+      it 'destroys the item and flashes success' do
+        sign_in @owner
+
+        expect do
+          delete :destroy, id: @todo_item, todo_list_id: @todo_list
+        end.to change(TodoItem, :count).by(-1)
 
         expect(flash[:notice]).to match(/^Item successfully deleted./)
+      end
+    end
+
+    context 'when the user does not own the containing list' do
+      it 'does nothing and returns an error' do
+        @user = create(:user)
+        sign_in @user
+
+        expect do
+          delete :destroy, id: @todo_item, todo_list_id: @todo_list
+        end.not_to change(TodoItem, :count)
+
+        expect_it_to_return_an_authorization_error
+      end
+    end
+
+    context 'when the user is not logged in' do
+      it 'does nothing and returns an error' do
+        expect do
+          delete :destroy, id: @todo_item, todo_list_id: @todo_list
+        end.not_to change(TodoItem, :count)
+
+        expect_it_to_require_the_user_be_signed_in
       end
     end
   end

--- a/spec/models/todo_item_spec.rb
+++ b/spec/models/todo_item_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe TodoItem, type: :model do
   it { should belong_to :todo_list }
   it { should validate_presence_of :todo_list }
 
+  it { should delegate_method(:user).to(:todo_list) }
+
   it { should validate_presence_of :name }
   it { should validate_length_of(:name).is_at_least(3) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it { should have_many :todo_lists }
+  it { should have_many(:todo_items).through(:todo_lists) }
 end

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -6,6 +6,6 @@ module Macros
 
   def expect_it_to_return_an_authorization_error
     expect(response).to redirect_to root_path
-    expect(flash[:alert]).to match(/^You are not the owner of that list or the list does not exist./)
+    expect(flash[:alert]).to match(/^You are not the owner of that [a-z]* or the [a-z]* does not exist./)
   end
 end


### PR DESCRIPTION
The TodoItems controller wasn't doing any checks to make sure that the
user owned the list they were adding items to, or deleting items from.

This has now been fixed.

Changes:
- Users now have many items through lists
- Items delegate :user to :todo_list
- Useer authentication and authorization done in the TodoItemsController

Pushing this now, will do some refactoring with the main TodoItems
feature push coming sooon.
