### PR TITLE
Items have basic descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'devise'
 
 gem 'codecov', require: false, group: :test
 
+gem 'redcarpet'
+
 gem 'rails_12factor', group: :production
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    redcarpet (3.3.4)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.4.4)
@@ -350,6 +351,7 @@ DEPENDENCIES
   pry-rails
   rails (= 4.2.6)
   rails_12factor
+  redcarpet
   rspec-rails (~> 3.4.2)
   rubocop (~> 0.40.0)
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/todo-list-items.scss
+++ b/app/assets/stylesheets/todo-list-items.scss
@@ -71,3 +71,33 @@
     text-decoration: line-through;
   }
 }
+
+.todo-item-description {
+  margin-bottom: 10px;
+  padding-bottom: 1em;
+  border-bottom: 1px solid;
+
+  h1 {
+    margin: 10.5px 0;
+    font-size: 17px;
+    font-weight: 500;
+  }
+
+  h2 {
+    margin: 10.5px 0;
+    font-size: 15px;
+    font-weight: 500;
+  }
+
+  h3 {
+    margin: 10.5px 0;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  h4 {
+    margin: 10.5px 0;
+    font-size: 12px;
+    font-weight: 500;
+  }
+}

--- a/app/controllers/todo_items_controller.rb
+++ b/app/controllers/todo_items_controller.rb
@@ -84,6 +84,6 @@ class TodoItemsController < ApplicationController
 
   def todo_item_params
     Time.zone = 'America/New_York'
-    params.require(:todo_item).permit(:name, :due_at)
+    params.require(:todo_item).permit(:name, :description, :due_at)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,13 @@ module ApplicationHelper
   def minimum_password_length
     @minimum_password_length ||= User.password_length.min
   end
+
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML,
+      no_intro_emphasis: true,
+      disabled_indented_codeblocks: true,
+    )
+    markdown.render(text).html_safe unless text.nil?
+  end
 end

--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -9,6 +9,8 @@ class TodoItem < ActiveRecord::Base
   validates :name, presence: true
   validates :name, length: { minimum: 3 }
 
+  validates :description, length: { maximum: 1024 }
+
   scope :priority, lambda {
     order("
       CASE WHEN completed_at IS NULL AND due_at < CURRENT_DATE + INTERVAL '7 days' THEN (1, due_at) END ASC,

--- a/app/views/todo_items/_modal_form.html.slim
+++ b/app/views/todo_items/_modal_form.html.slim
@@ -22,7 +22,7 @@
                                                 value: item.due_at_in_user_zone
             .form-group
               = f.label :description
-              = f.text_area :description, class: 'form-control'
+              = f.text_area :description, rows: 10, class: 'form-control'
             .form-group
               = f.submit 'Update Item', class: 'btn btn-primary form-control'
 

--- a/app/views/todo_items/_modal_form.html.slim
+++ b/app/views/todo_items/_modal_form.html.slim
@@ -21,6 +21,9 @@
               = f.datetime_local_field :due_at, class: 'form-control', step: 900,
                                                 value: item.due_at_in_user_zone
             .form-group
+              = f.label :description
+              = f.text_area :description, class: 'form-control'
+            .form-group
               = f.submit 'Update Item', class: 'btn btn-primary form-control'
 
       .modal-footer

--- a/app/views/todo_items/_show.html.slim
+++ b/app/views/todo_items/_show.html.slim
@@ -14,14 +14,15 @@ li[class=todo_list_item_classes id=item.id data-sortorder=item.sort_order]
     = render 'todo_items/modal_form', item: item
   .list-group-item-text.todo-item-description
     = markdown(item.description)
-  - if item.complete?
-    p.list-group-item-text
-      = item.tag_for_time(:completed)
-  - else
-    p.list-group-item-text
-      = item.tag_for_time(:due)
-    p.list-group-item-text
-      = item.tag_for_time(:created)
+  .list-item-times
+    - if item.complete?
+      p.list-group-item-text
+        = item.tag_for_time(:completed)
+    - else
+      p.list-group-item-text
+        = item.tag_for_time(:due)
+      p.list-group-item-text
+        = item.tag_for_time(:created)
   .completion-toggle-box
     - if item.complete?
       = link_to todo_list_uncomplete_path(@todo_list, item),

--- a/app/views/todo_items/_show.html.slim
+++ b/app/views/todo_items/_show.html.slim
@@ -12,6 +12,8 @@ li[class=todo_list_item_classes id=item.id data-sortorder=item.sort_order]
               data: { toggle: 'modal', keyboard: true },
               class: 'todo-item-edit-button'
     = render 'todo_items/modal_form', item: item
+  .list-group-item-text.todo-item-description
+    = markdown(item.description)
   - if item.complete?
     p.list-group-item-text
       = item.tag_for_time(:completed)

--- a/app/views/todo_items/complete.js.erb
+++ b/app/views/todo_items/complete.js.erb
@@ -3,7 +3,7 @@ $('#todo-items-group').append("<%= j render 'todo_items/show', item: @todo_item 
 
 $('#alerts').append("<%= j render 'layouts/alert', type: :info, msg: 'Item marked complete' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li').sort(sortPriority).appendTo('#todo-items-group');
+$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/create.js.erb
+++ b/app/views/todo_items/create.js.erb
@@ -1,7 +1,7 @@
 $('#todo-items-group').append("<%= j render 'todo_items/show', item: @todo_item %>");
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item added successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>')
-$('#todo-items-group li').sort(sortPriority).appendTo('#todo-items-group')
+$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/uncomplete.js.erb
+++ b/app/views/todo_items/uncomplete.js.erb
@@ -3,7 +3,7 @@ $('#todo-items-group').append("<%= j render 'todo_items/show', item: @todo_item 
 
 $('#alerts').append("<%= j render 'layouts/alert', type: :warning, msg: 'Item marked incomplete' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li').sort(sortPriority).appendTo('#todo-items-group');
+$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/update.js.erb
+++ b/app/views/todo_items/update.js.erb
@@ -2,7 +2,7 @@ $('#modal-for-item-<%= @todo_item.id %> .close').click();
 $('#todo-items-group li#<%= @todo_item.id %>').replaceWith("<%= j render 'todo_items/show', item: @todo_item %>");
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item updated successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li').sort(sortPriority).appendTo('#todo-items-group');
+$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group');
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/db/migrate/20160707210239_add_description_to_todo_items.rb
+++ b/db/migrate/20160707210239_add_description_to_todo_items.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToTodoItems < ActiveRecord::Migration
+  def change
+    add_column :todo_items, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160629141940) do
+ActiveRecord::Schema.define(version: 20160707210239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20160629141940) do
     t.datetime "updated_at",   null: false
     t.datetime "completed_at"
     t.datetime "due_at"
+    t.text     "description"
   end
 
   add_index "todo_items", ["todo_list_id"], name: "index_todo_items_on_todo_list_id", using: :btree

--- a/spec/controllers/todo_items_controller_spec.rb
+++ b/spec/controllers/todo_items_controller_spec.rb
@@ -156,6 +156,14 @@ RSpec.describe TodoItemsController, type: :controller do
           expect(@todo_item.name).to eq 'New Name Here'
         end
 
+        it 'accepts an optional description' do
+          put :update, id: @todo_item, todo_list_id: @todo_list,
+                       todo_item: { description: 'This is the new description' }
+          @todo_item.reload
+
+          expect(@todo_item.description).to eq 'This is the new description'
+        end
+
         it 'redirects to the list with status 303' do
           put :update, id: @todo_item, todo_list_id: @todo_list,
                        todo_item: { name: 'New Name Here' }

--- a/spec/models/todo_item_spec.rb
+++ b/spec/models/todo_item_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe TodoItem, type: :model do
   it { should validate_presence_of :name }
   it { should validate_length_of(:name).is_at_least(3) }
 
+  it { should validate_length_of(:description).is_at_most(1024) }
+
   describe 'complete!' do
     it 'sets the completed_at date' do
       @todo_item = build(:todo_item)


### PR DESCRIPTION
Added basic markdown format descriptions to Todo items.

Expecting future updates that can, for example, add hashtags and/or mentions of other users, but keeping it simple for now.
