### PR TITLE
Use explicitly secure github urls in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'bootswatch-rails'
 gem 'data-confirm-modal',
-    git: 'git://github.com/eToThePiIPower/data-confirm-modal.git',
+    git: 'https://github.com/eToThePiIPower/data-confirm-modal.git',
     branch: 'feat/add-custom-data-modal-class-attribute-support'
 gem 'font-awesome-rails'
 gem 'slim', '~> 3.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/eToThePiIPower/data-confirm-modal.git
+  remote: https://github.com/eToThePiIPower/data-confirm-modal.git
   revision: 9f5cdfec6f0c855b76e165c14248eb7ca59b885d
   branch: feat/add-custom-data-modal-class-attribute-support
   specs:


### PR DESCRIPTION
bundler-audit was calling an URL in the Gemfile using `git://` instead of `https://`
