### PR TITLE
Feature: Tabbed Todo Lists and Add Item Slider

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -11,6 +11,8 @@ linters:
     enabled: false
   PropertySortOrder:
     order: smacss
+  SelectorDepth:
+    max_depth: 4
   SelectorFormat:
     ignored_names: ['field_with_errors']
   VendorPrefix:

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,6 +66,10 @@ $(document).ajaxComplete(function() {
 $(document).ready(function() {
   $.timeago.settings.allowFuture = true;
   bindHandlers();
+
+  $('.slide-up-toggler').click(function() {
+    $('.slide-up-panel').slideToggle("slow");
+  });
 });
 
 /* global dataConfirmModal */

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -8,60 +8,10 @@
 @import 'buttons';
 @import 'flex-list';
 @import 'modals';
+@import 'nav-with-tabs';
 @import 'progressbar';
+@import 'slide-up';
 @import 'todo-list-items';
-
-.slide-up-toggler {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  padding: .5em;
-  background-color: #fff;
-  text-align: center;
-  box-shadow: 0 -6px 12px rgba(0, 0, 0, .175);
-  z-index: 10;
-}
-
-.slide-up-panel {
-  display: none;
-  position: fixed;
-  right: 0;
-  bottom: 28px;
-  left: 0;
-  padding: 1em;
-  background-color: #fff;
-  box-shadow: 0 -6px 12px rgba(0, 0, 0, .175);
-  z-index: 5;
-}
-
-@media (min-width: 768px) {
-  .slide-up-toggler,
-  .slide-up-panel {
-    width: 750px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-}
-
-@media (min-width: 992px) {
-  .slide-up-toggler,
-  .slide-up-panel {
-    width: 970px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-}
-
-@media (min-width: 1200px) {
-  .slide-up-toggler,
-  .slide-up-panel {
-    width: 1170px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-}
 
 .jumbotron {
   background-color: $brand-primary;
@@ -102,23 +52,5 @@
         content: attr(shorttime);
       }
     }
-  }
-}
-
-.panel.with-nav-tabs {
-  .panel-heading {
-    padding-bottom: 0;
-  }
-
-  .nav-tabs {
-    border-bottom: 0;
-
-    li:not(.active) a {
-      background-color: transparent;
-    }
-  }
-
-  .nav-justified {
-    margin-bottom: -1px;
   }
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,58 @@
 @import 'progressbar';
 @import 'todo-list-items';
 
+.slide-up-toggler {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: .5em;
+  background-color: #fff;
+  text-align: center;
+  box-shadow: 0 -6px 12px rgba(0, 0, 0, .175);
+  z-index: 10;
+}
+
+.slide-up-panel {
+  display: none;
+  position: fixed;
+  right: 0;
+  bottom: 28px;
+  left: 0;
+  padding: 1em;
+  background-color: #fff;
+  box-shadow: 0 -6px 12px rgba(0, 0, 0, .175);
+  z-index: 5;
+}
+
+@media (min-width: 768px) {
+  .slide-up-toggler,
+  .slide-up-panel {
+    width: 750px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
+
+@media (min-width: 992px) {
+  .slide-up-toggler,
+  .slide-up-panel {
+    width: 970px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
+
+@media (min-width: 1200px) {
+  .slide-up-toggler,
+  .slide-up-panel {
+    width: 1170px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
+
 .jumbotron {
   background-color: $brand-primary;
   color: $body-bg;
@@ -56,6 +108,17 @@
 .panel.with-nav-tabs {
   .panel-heading {
     padding-bottom: 0;
-    border-bottom-color: transparent;
+  }
+
+  .nav-tabs {
+    border-bottom: 0;
+
+    li:not(.active) a {
+      background-color: transparent;
+    }
+  }
+
+  .nav-justified {
+    margin-bottom: -1px;
   }
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -52,3 +52,10 @@
     }
   }
 }
+
+.panel.with-nav-tabs {
+  .panel-heading {
+    padding-bottom: 0;
+    border-bottom-color: transparent;
+  }
+}

--- a/app/assets/stylesheets/nav-with-tabs.scss
+++ b/app/assets/stylesheets/nav-with-tabs.scss
@@ -1,0 +1,34 @@
+.panel.with-nav-tabs {
+  .panel-heading {
+    padding-bottom: 0;
+  }
+
+  .nav-tabs {
+    border-bottom: 0;
+
+    li:not(.active) a {
+      background-color: transparent;
+    }
+
+    .active.tab-danger a {
+      background: $state-danger-bg;
+      color: $state-danger-text;
+    }
+  }
+
+  .nav-justified {
+    margin-bottom: -1px;
+  }
+
+  .list-group {
+    margin-bottom: 0;
+
+    > li:first-child {
+      border-top: 0;
+    }
+  }
+}
+
+.panel.with-bottom-slider {
+  margin-bottom: 3em;
+}

--- a/app/assets/stylesheets/slide-up.scss
+++ b/app/assets/stylesheets/slide-up.scss
@@ -1,0 +1,51 @@
+.slide-up-toggler {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: .5em;
+  background-color: $body-bg;
+  text-align: center;
+  box-shadow: 0 -6px 12px rgba(0, 0, 0, .175);
+  z-index: 10;
+}
+
+.slide-up-panel {
+  display: none;
+  position: fixed;
+  right: 0;
+  bottom: 28px;
+  left: 0;
+  padding: 1em;
+  background-color: $body-bg;
+  box-shadow: 0 -6px 12px rgba(0, 0, 0, .175);
+  z-index: 5;
+}
+
+@media (min-width: $screen-sm) {
+  .slide-up-toggler,
+  .slide-up-panel {
+    width: $container-sm;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
+
+@media (min-width: $screen-md) {
+  .slide-up-toggler,
+  .slide-up-panel {
+    width: $container-md;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
+
+@media (min-width: $screen-lg) {
+  .slide-up-toggler,
+  .slide-up-panel {
+    width: $container-lg;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}

--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -11,6 +11,14 @@ class TodoItem < ActiveRecord::Base
 
   validates :description, length: { maximum: 1024 }
 
+  scope :active, lambda {
+    where('completed_at IS NULL OR completed_at >= ?', 7.days.ago)
+  }
+
+  scope :archived, lambda {
+    where('completed_at < ?', 7.days.ago)
+  }
+
   scope :priority, lambda {
     order("
       CASE WHEN completed_at IS NULL AND due_at < CURRENT_DATE + INTERVAL '7 days' THEN (1, due_at) END ASC,

--- a/app/views/todo_lists/show.html.slim
+++ b/app/views/todo_lists/show.html.slim
@@ -8,7 +8,7 @@
     = render 'shared/progressbar',
       percent: @todo_list.percent_complete
 
-  .panel.panel-default.with-nav-tabs
+  .panel.panel-default.with-nav-tabs.with-bottom-slider
     .panel-heading
       ul.nav.nav-tabs[role='tablist']
         li.active

--- a/app/views/todo_lists/show.html.slim
+++ b/app/views/todo_lists/show.html.slim
@@ -10,33 +10,38 @@
 
   .panel.panel-default.with-nav-tabs
     .panel-heading
-      ul.nav.nav-tabs
+      ul.nav.nav-tabs[role='tablist']
         li.active
           a[data-toggle='tab' href='#todo-list-active'] Active Tasks
         li
-          a[data-toggle='tab' href='#todo-list-archived'] Archived Tasks
+          a[data-toggle='tab' href='#todo-list-archived'] Archives
         li.pull-right
           a[data-toggle='tab' href='#todo-list-settings']
             i.fa.fa-cog
-            | &nbsp; Settings
+            span.sr-only Settings
 
     .tab-content
 
       .tab-pane.fade.in.active#todo-list-active
         - if @todo_items.active.empty?
-          .well
+          .panel-body
             h2 This list is empty, or you have completed everything!
             p.lead Try adding an item below.
         - else
           ul.list-group#todo-items-group
             - @todo_items.active.each do |item|
               = render 'todo_items/show', item: item
-        .panel-body
+
+        button.slide-up-toggler.btn.btn-default
+          i.fa.fa-chevron-up
+          span &nbsp;Add an Item&nbsp;
+          i.fa.fa-chevron-up
+        .slide-up-panel
           = render 'todo_items/form'
 
       .tab-pane.fade#todo-list-archived
         - if @todo_items.archived.empty?
-          .well
+          .panel-body
             h2 There are no archived items!
             p.lead Items will appear here seven days after completion
         - else

--- a/app/views/todo_lists/show.html.slim
+++ b/app/views/todo_lists/show.html.slim
@@ -1,4 +1,4 @@
-.container
+.container#todo-list-show
   h1.no-widows
     = @todo_list.name
   p.lead
@@ -8,14 +8,42 @@
     = render 'shared/progressbar',
       percent: @todo_list.percent_complete
 
-  - if @todo_items.empty?
-    .well
-      h2 This list is empty!
-      p.lead Try adding an item below.
+  .panel.panel-default.with-nav-tabs
+    .panel-heading
+      ul.nav.nav-tabs
+        li.active
+          a[data-toggle='tab' href='#todo-list-active'] Active Tasks
+        li
+          a[data-toggle='tab' href='#todo-list-archived'] Archived Tasks
+        li.pull-right
+          a[data-toggle='tab' href='#todo-list-settings']
+            i.fa.fa-cog
+            | &nbsp; Settings
 
-  - else
-    ul.list-group#todo-items-group
-      - @todo_items.each do |item|
-        = render 'todo_items/show', item: item
+    .tab-content
 
-  = render 'todo_items/form'
+      .tab-pane.fade.in.active#todo-list-active
+        - if @todo_items.active.empty?
+          .well
+            h2 This list is empty, or you have completed everything!
+            p.lead Try adding an item below.
+        - else
+          ul.list-group#todo-items-group
+            - @todo_items.active.each do |item|
+              = render 'todo_items/show', item: item
+        .panel-body
+          = render 'todo_items/form'
+
+      .tab-pane.fade#todo-list-archived
+        - if @todo_items.archived.empty?
+          .well
+            h2 There are no archived items!
+            p.lead Items will appear here seven days after completion
+        - else
+          ul.list-group#todo-items-group
+            - @todo_items.archived.each do |item|
+              = render 'todo_items/show', item: item
+
+      .tab-pane.fade#todo-list-settings
+        .panel-body
+          = render 'form', legend: 'Edit List'

--- a/spec/features/user_adds_a_todo_item_ajax_spec.rb
+++ b/spec/features/user_adds_a_todo_item_ajax_spec.rb
@@ -1,6 +1,6 @@
 require 'support/share_db_connection'
 
-feature 'User adds a todo item', js: true do
+feature 'User adds a todo item via AJAX', js: true do
   before do
     @user = create(:user)
     @todo_list = @user.todo_lists.create(attributes_for(:todo_list))
@@ -17,8 +17,11 @@ feature 'User adds a todo item', js: true do
 
     expect(page).to have_xpath("//div[@aria-valuenow='100']")
 
-    fill_in 'New Item', with: 'My Newest Task'
-    click_button 'Add Item'
+    click_on 'Add an Item'
+    within '#new_todo_item' do
+      fill_in 'New Item', with: 'My Newest Task'
+      click_button 'Add Item'
+    end
 
     expect(find('#alerts')).to have_content('Item added successfully')
     expect(page).to have_xpath("//div[@aria-valuenow='50']")

--- a/spec/views/todo_lists/show.html.slim_spec.rb
+++ b/spec/views/todo_lists/show.html.slim_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'todo_lists/show.html.slim' do
 
   context 'when there are todo items' do
     it 'highlights completed todo items' do
-      @todo_list = build(:todo_list_with_items, items_count: 10, completed_items_count: 3)
+      @todo_list = create(:todo_list_with_items, items_count: 10, completed_items_count: 3)
       assign(:todo_list, @todo_list)
       assign(:todo_items, @todo_list.todo_items)
 
@@ -24,7 +24,7 @@ RSpec.describe 'todo_lists/show.html.slim' do
     end
 
     it 'mutes archived todo items' do
-      @todo_list = build(:todo_list_with_items, items_count: 10, old_items_count: 3)
+      @todo_list = create(:todo_list_with_items, items_count: 10, old_items_count: 3)
       assign(:todo_list, @todo_list)
       assign(:todo_items, @todo_list.todo_items)
 
@@ -35,9 +35,12 @@ RSpec.describe 'todo_lists/show.html.slim' do
     end
 
     it 'flags overdue todo items' do
-      @todo_list = build(:todo_list_with_items, items_count: 10)
+      @todo_list = create(:todo_list_with_items, items_count: 10)
       @todo_items = @todo_list.todo_items
-      @todo_items[0..2].each { |i| i.due_at = 1.day.ago }
+      @todo_items[0..2].each do |i|
+        i.due_at = 1.day.ago
+        i.save
+      end
       assign(:todo_list, @todo_list)
       assign(:todo_items, @todo_items)
 


### PR DESCRIPTION
Because the UX on long lists was getting tedious, particularly with respect to having to scroll to the bottom of a long list to add an item, then up again to see where the new item was added (often in the middle before all the archived items), this two-fold feature adds the following:
- Todo Lists now appear as a tabbed panel, with three tabs:
  - Active (and recently completed)
  - Archived (completed over seven days ago)
  - Settings (the edit list form)
- When the Active tab is active, an 'add item' button is now fixed to the bottom of the screen
  no matter where the user is scrolled.
  - Clicking this toggles the add item form to slide up, making it available anywhere the user is 
    scrolled.
