### PR TITLE
Hotfix: AJAX fixes for empty lists and archived items

### DIFF
--- a/app/assets/stylesheets/todo_lists.scss
+++ b/app/assets/stylesheets/todo_lists.scss
@@ -1,7 +1,8 @@
 // Place all the styles related to the todo_lists controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-#todo-items-group,
+#todo-items-active,
+#todo-items-archived,
 #todo-lists-group {
   .actions {
     position: absolute;

--- a/app/views/todo_items/complete.js.erb
+++ b/app/views/todo_items/complete.js.erb
@@ -1,9 +1,9 @@
-$('#todo-items-group #<%= @todo_item.id %>').remove();
-$('#todo-items-group').append("<%= j render 'todo_items/show', item: @todo_item %>");
+$('#todo-items-active #<%= @todo_item.id %>').remove();
+$('#todo-items-active').append("<%= j render 'todo_items/show', item: @todo_item %>");
 
 $('#alerts').append("<%= j render 'layouts/alert', type: :info, msg: 'Item marked complete' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group')
+$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/create.js.erb
+++ b/app/views/todo_items/create.js.erb
@@ -1,7 +1,7 @@
-$('#todo-items-group').append("<%= j render 'todo_items/show', item: @todo_item %>");
+$('#todo-items-active').append("<%= j render 'todo_items/show', item: @todo_item %>");
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item added successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>')
-$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group')
+$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/create.js.erb
+++ b/app/views/todo_items/create.js.erb
@@ -8,3 +8,8 @@ $('.progress-bar')
   .removeClass('progress-bar-success')
   .removeClass('progress-bar-info')
   .addClass('<%= @todo_list.progress_bar_type %>')
+
+// Reload if we just added the first item
+<% if @todo_list.todo_items.active.size == 1 %>
+location.reload()
+<% end %>

--- a/app/views/todo_items/destroy.js.erb
+++ b/app/views/todo_items/destroy.js.erb
@@ -8,3 +8,8 @@ $('.progress-bar')
   .removeClass('progress-bar-success')
   .removeClass('progress-bar-info')
   .addClass('<%= @todo_list.progress_bar_type %>');
+
+// Reload if we just removed the last item
+<% if @todo_list.todo_items.active.empty? %>
+location.reload()
+<% end %>

--- a/app/views/todo_items/destroy.js.erb
+++ b/app/views/todo_items/destroy.js.erb
@@ -1,7 +1,7 @@
-$('#todo-items-group #<%= @todo_item.id%>').remove();
+$('#todo-items-active #<%= @todo_item.id%>').remove();
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item removed successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li').sort(sortPriority).appendTo('#todo-items-group');
+$('#todo-items-active li').sort(sortPriority).appendTo('#todo-items-active');
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/uncomplete.js.erb
+++ b/app/views/todo_items/uncomplete.js.erb
@@ -1,9 +1,9 @@
-$('#todo-items-group #<%= @todo_item.id %>').remove();
-$('#todo-items-group').append("<%= j render 'todo_items/show', item: @todo_item %>");
+$('#todo-items-active #<%= @todo_item.id %>').remove();
+$('#todo-items-active').append("<%= j render 'todo_items/show', item: @todo_item %>");
 
 $('#alerts').append("<%= j render 'layouts/alert', type: :warning, msg: 'Item marked incomplete' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group')
+$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/update.js.erb
+++ b/app/views/todo_items/update.js.erb
@@ -1,8 +1,8 @@
 $('#modal-for-item-<%= @todo_item.id %> .close').click();
-$('#todo-items-group li#<%= @todo_item.id %>').replaceWith("<%= j render 'todo_items/show', item: @todo_item %>");
+$('#todo-items-active li#<%= @todo_item.id %>').replaceWith("<%= j render 'todo_items/show', item: @todo_item %>");
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item updated successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-group li.todo-list-item').sort(sortPriority).appendTo('#todo-items-group');
+$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active');
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_lists/show.html.slim
+++ b/app/views/todo_lists/show.html.slim
@@ -28,7 +28,7 @@
             h2 This list is empty, or you have completed everything!
             p.lead Try adding an item below.
         - else
-          ul.list-group#todo-items-group
+          ul.list-group#todo-items-active
             - @todo_items.active.each do |item|
               = render 'todo_items/show', item: item
 
@@ -45,7 +45,7 @@
             h2 There are no archived items!
             p.lead Items will appear here seven days after completion
         - else
-          ul.list-group#todo-items-group
+          ul.list-group#todo-items-archived
             - @todo_items.archived.each do |item|
               = render 'todo_items/show', item: item
 

--- a/spec/features/user_adds_a_todo_item_ajax_spec.rb
+++ b/spec/features/user_adds_a_todo_item_ajax_spec.rb
@@ -30,6 +30,7 @@ feature 'User adds a todo item via AJAX', js: true do
   end
 
   scenario 'it keeps archived items in the archives' do
+    create(:todo_item, todo_list: @todo_list, created_at: 1.day.ago) # Ensure we aren't creating first active item
     create(:todo_item, todo_list: @todo_list, created_at: 9.days.ago, completed_at: 8.days.ago)
     visit todo_list_path @todo_list
 

--- a/spec/features/user_adds_a_todo_item_ajax_spec.rb
+++ b/spec/features/user_adds_a_todo_item_ajax_spec.rb
@@ -28,4 +28,19 @@ feature 'User adds a todo item via AJAX', js: true do
     expect(first('.todo-list-item')).to have_content 'My Newest Task'
     expect(first('.todo-list-item')).to have_content('Created less than a minute ago')
   end
+
+  scenario 'it keeps archived items in the archives' do
+    create(:todo_item, todo_list: @todo_list, created_at: 9.days.ago, completed_at: 8.days.ago)
+    visit todo_list_path @todo_list
+
+    click_on 'Add an Item'
+    within '#new_todo_item' do
+      fill_in 'New Item', with: 'My Newest Task'
+      click_button 'Add Item'
+    end
+
+    expect(page).not_to have_css '#todo-items-active li.todo-list-item-archived'
+    click_on 'Archives'
+    expect(page).to have_css '#todo-items-archived li.todo-list-item-archived'
+  end
 end

--- a/spec/features/user_completes_a_todo_item_ajax_spec.rb
+++ b/spec/features/user_completes_a_todo_item_ajax_spec.rb
@@ -22,4 +22,16 @@ feature 'User adds a todo item', js: true do
     expect(page).to have_xpath("//div[@aria-valuenow='100']")
     expect(find('.todo-list-item.todo-list-item-complete')).to have_content('Completed less than a minute ago')
   end
+
+  scenario 'it keeps archived items in the archives' do
+    create(:todo_item, todo_list: @todo_list, created_at: 2.days.ago)
+    create(:todo_item, todo_list: @todo_list, created_at: 9.days.ago, completed_at: 8.days.ago)
+    visit todo_list_path @todo_list
+
+    click_link 'Complete this item'
+
+    expect(page).not_to have_css '#todo-items-active li.todo-list-item-archived'
+    click_on 'Archives'
+    expect(page).to have_css '#todo-items-archived li.todo-list-item-archived'
+  end
 end

--- a/spec/features/user_uncompletes_a_todo_item_ajax_spec.rb
+++ b/spec/features/user_uncompletes_a_todo_item_ajax_spec.rb
@@ -23,4 +23,16 @@ feature 'User adds a todo item', js: true do
     expect(page).to have_xpath("//div[@aria-valuenow='0']")
     expect(find('.todo-list-item.todo-list-item-incomplete')).to have_content('Item 1')
   end
+
+  scenario 'it keeps archived items in the archives' do
+    create(:todo_item, todo_list: @todo_list, created_at: 2.days.ago, completed_at: 1.day.ago)
+    create(:todo_item, todo_list: @todo_list, created_at: 9.days.ago, completed_at: 8.days.ago)
+    visit todo_list_path @todo_list
+
+    click_link 'Uncomplete this item'
+
+    expect(page).not_to have_css '#todo-items-active li.todo-list-item-archived'
+    click_on 'Archives'
+    expect(page).to have_css '#todo-items-archived li.todo-list-item-archived'
+  end
 end


### PR DESCRIPTION
AJAX requests weren't handling empty lists and archived items correctly. The following fixes are implemented:
- AJAX CREATE doesn't replace the "Empty List" descriptive panel with a list-group containing the first item
- AJAX DESTROY doesn't replace the empty list-group with the "Empty List descriptive panel
- Both the following fixed by forcing a page reload in the appropriate circumstance 
  - (@todo_list.todo_items.active.size == ?)
- AJAX requests should keep archived items in the Archives tab instead of remixing them into the Active tab
  - Fixed by removing duplicate ids from the two list-groups and only sorting the active items.
