### PR TITLE
Bug fix: Lists can't scroll after ajax update

### DIFF
--- a/app/assets/stylesheets/todo-list-items.scss
+++ b/app/assets/stylesheets/todo-list-items.scss
@@ -4,10 +4,9 @@
 @mixin todo-list-item-variant($state, $base, $color) {
   .todo-list-item {
     &.todo-list-item-#{$state} {
-      @extend .list-group-item-#{$base};
       @include reset-modals;
+      border-left: 5px solid $color;
 
-      a,
       a:hover {
         color: $color;
       }
@@ -25,12 +24,10 @@
   }
 }
 
-@include todo-list-item-variant(complete, success, $state-success-text);
-@include todo-list-item-variant(due-now, warning, $state-warning-text);
-@include todo-list-item-variant(overdue, danger, $state-danger-text);
-
-@include list-group-item-variant(muted, $state-success-muted-bg, $state-success-muted-text);
-@include todo-list-item-variant(archived, muted, $state-success-muted-text);
+@include todo-list-item-variant(complete, $state-success-bg, $state-success-text);
+@include todo-list-item-variant(due-now, $state-warning-bg, $state-warning-text);
+@include todo-list-item-variant(overdue, $state-danger-bg, $state-danger-text);
+@include todo-list-item-variant(archived, $state-success-muted-bg, $state-success-muted-text);
 
 .clear-field-link,
 .reset-field-link {

--- a/app/views/todo_items/complete.js.erb
+++ b/app/views/todo_items/complete.js.erb
@@ -1,9 +1,7 @@
-$('#todo-items-active #<%= @todo_item.id %>').remove();
-$('#todo-items-active').append("<%= j render 'todo_items/show', item: @todo_item %>");
+$('#todo-items-active #<%= @todo_item.id %>').before("<%= j render 'todo_items/show', item: @todo_item %>").detach();
 
 $('#alerts').append("<%= j render 'layouts/alert', type: :info, msg: 'Item marked complete' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/create.js.erb
+++ b/app/views/todo_items/create.js.erb
@@ -1,7 +1,6 @@
 $('#todo-items-active').append("<%= j render 'todo_items/show', item: @todo_item %>");
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item added successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>')
-$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/destroy.js.erb
+++ b/app/views/todo_items/destroy.js.erb
@@ -1,7 +1,6 @@
-$('#todo-items-active #<%= @todo_item.id%>').remove();
+$('#todo-items-active #<%= @todo_item.id%>').detach();
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item removed successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-active li').sort(sortPriority).appendTo('#todo-items-active');
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/uncomplete.js.erb
+++ b/app/views/todo_items/uncomplete.js.erb
@@ -1,9 +1,7 @@
-$('#todo-items-active #<%= @todo_item.id %>').remove();
-$('#todo-items-active').append("<%= j render 'todo_items/show', item: @todo_item %>");
+$('#todo-items-active #<%= @todo_item.id %>').before("<%= j render 'todo_items/show', item: @todo_item %>").detach();
 
 $('#alerts').append("<%= j render 'layouts/alert', type: :warning, msg: 'Item marked incomplete' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active')
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')

--- a/app/views/todo_items/update.js.erb
+++ b/app/views/todo_items/update.js.erb
@@ -1,8 +1,8 @@
 $('#modal-for-item-<%= @todo_item.id %> .close').click();
-$('#todo-items-active li#<%= @todo_item.id %>').replaceWith("<%= j render 'todo_items/show', item: @todo_item %>");
+window.scrollBy(0,0);
+$('#todo-items-active li#<%= @todo_item.id %>').before("<%= j render 'todo_items/show', item: @todo_item %>").detach();
 $('#alerts').append("<%= j render 'layouts/alert', type: :success, msg: 'Item updated successfully' %>");
 $('.progress-bar').attr('style', "width:<%= @todo_list.percent_complete %>%;").attr('aria-valuenow', '<%= @todo_list.percent_complete %>');
-$('#todo-items-active li.todo-list-item').sort(sortPriority).appendTo('#todo-items-active');
 $('.progress-bar')
   .removeClass('progress-bar-danger')
   .removeClass('progress-bar-warning')


### PR DESCRIPTION
Fixed a long-standing bug that prevented scrolling after an AJAX update
calling .remove() or .replaceWith()—which calls remove() internally—on the
list. Fixed by using .detach() or .before().detach() in the AJAX
responses instead.

Also took the time to tweak styles again.
